### PR TITLE
Add alt text to images

### DIFF
--- a/CymaSpacesnipeIT.html
+++ b/CymaSpacesnipeIT.html
@@ -94,6 +94,7 @@
                     const img = document.createElement('img')
                     if (row.image) {
                         img.src = row.image;
+                        img.alt = row.name || 'asset image';
                         item.appendChild(img);
                     }
 

--- a/index.html
+++ b/index.html
@@ -128,8 +128,8 @@
 
             <h1>Lasered Artworks</h1>
             <div class="images">
-                <img src="./Hobby/Lasering/LaserCutting.jpg">
-                <img src="./Hobby/Lasering/LaserCutting2.jpg">
+                <img src="./Hobby/Lasering/LaserCutting.jpg" alt="Laser Cutting">
+                <img src="./Hobby/Lasering/LaserCutting2.jpg" alt="Laser Cutting2">
             </div>
 
             <div class="artwork">
@@ -144,18 +144,18 @@
                                 title="Videos of lasered metal cards" allowfullscreen></iframe>
                         </div>
                         <div class="images">
-                            <img src="./Hobby/Lasering/Metalsheets/castlePictureFrame.jpg">
-                            <img src="./Hobby/Lasering/Metalsheets/darkSoul.jpg">
-                            <img src="./Hobby/Lasering/Metalsheets/darksoul2.jpg">
-                            <img src="./Hobby/Lasering/Metalsheets/deafHero3.jpg">
-                            <img src="./Hobby/Lasering/Metalsheets/deafHero4.jpg">
-                            <img src="./Hobby/Lasering/Metalsheets/framedDeafHeroes.jpg">
-                            <img src="./Hobby/Lasering/Metalsheets/framedDeafHeroes2.jpg">
-                            <img src="./Hobby/Lasering/Metalsheets/MylesHaptics.jpg">
-                            <img src="./Hobby/Lasering/Metalsheets/mylesHero.jpg">
-                            <img src="./Hobby/Lasering/Metalsheets/PreppingFrames.jpg">
-                            <img src="./Hobby/Lasering/Metalsheets/PreppingFrames.jpg">
-                            <img src="./Hobby/Lasering/Metalsheets/steelsheet.jpg">
+                            <img src="./Hobby/Lasering/Metalsheets/castlePictureFrame.jpg" alt="castle Picture Frame">
+                            <img src="./Hobby/Lasering/Metalsheets/darkSoul.jpg" alt="dark Soul">
+                            <img src="./Hobby/Lasering/Metalsheets/darksoul2.jpg" alt="darksoul2">
+                            <img src="./Hobby/Lasering/Metalsheets/deafHero3.jpg" alt="deaf Hero3">
+                            <img src="./Hobby/Lasering/Metalsheets/deafHero4.jpg" alt="deaf Hero4">
+                            <img src="./Hobby/Lasering/Metalsheets/framedDeafHeroes.jpg" alt="framed Deaf Heroes">
+                            <img src="./Hobby/Lasering/Metalsheets/framedDeafHeroes2.jpg" alt="framed Deaf Heroes2">
+                            <img src="./Hobby/Lasering/Metalsheets/MylesHaptics.jpg" alt="Myles Haptics">
+                            <img src="./Hobby/Lasering/Metalsheets/mylesHero.jpg" alt="myles Hero">
+                            <img src="./Hobby/Lasering/Metalsheets/PreppingFrames.jpg" alt="Prepping Frames">
+                            <img src="./Hobby/Lasering/Metalsheets/PreppingFrames.jpg" alt="Prepping Frames">
+                            <img src="./Hobby/Lasering/Metalsheets/steelsheet.jpg" alt="steelsheet">
                         </div>
                     </div>
                 </div>
@@ -167,11 +167,11 @@
                         cafe!</a></p>
                 <div class="medias">
                     <div class="images">
-                        <img src="./Hobby/Lasering//WoodenCoasters/cymaSpaceLogo.jpg">
-                        <img src="./Hobby/Lasering//WoodenCoasters/cymaSpaceLogo2.jpg">
-                        <img src="./Hobby/Lasering//WoodenCoasters/cymaSpaceLogo3.jpg">
-                        <img src="./Hobby/Lasering//WoodenCoasters/GivingTree.jpg">
-                        <img src="./Hobby/Lasering//WoodenCoasters/GivingTree2.jpg">
+                        <img src="./Hobby/Lasering//WoodenCoasters/cymaSpaceLogo.jpg" alt="cyma Space Logo">
+                        <img src="./Hobby/Lasering//WoodenCoasters/cymaSpaceLogo2.jpg" alt="cyma Space Logo2">
+                        <img src="./Hobby/Lasering//WoodenCoasters/cymaSpaceLogo3.jpg" alt="cyma Space Logo3">
+                        <img src="./Hobby/Lasering//WoodenCoasters/GivingTree.jpg" alt="Giving Tree">
+                        <img src="./Hobby/Lasering//WoodenCoasters/GivingTree2.jpg" alt="Giving Tree2">
                     </div>
                 </div>
             </div>
@@ -181,10 +181,10 @@
                 <p>It turns out that my laser cutter works pretty great on rocks, ceramic, etc!</p>
                 <div class="medias">
                     <div class="images">
-                        <img src="./Hobby/Lasering/Cemaric/Andre.jpg">
-                        <img src="./Hobby/Lasering/Cemaric/CymaSpaceLogo.jpg">
-                        <img src="./Hobby/Lasering/Cemaric/CymaSpaceLogo2.jpg">
-                        <img src="./Hobby/Lasering/Cemaric/Squeaky.jpg">
+                        <img src="./Hobby/Lasering/Cemaric/Andre.jpg" alt="Andre">
+                        <img src="./Hobby/Lasering/Cemaric/CymaSpaceLogo.jpg" alt="Cyma Space Logo">
+                        <img src="./Hobby/Lasering/Cemaric/CymaSpaceLogo2.jpg" alt="Cyma Space Logo2">
+                        <img src="./Hobby/Lasering/Cemaric/Squeaky.jpg" alt="Squeaky">
                     </div>
                 </div>
             </div>
@@ -196,11 +196,11 @@
                 <div class="medias">
                     <div class="medias">
                         <div class="images">
-                            <img src="./Hobby/Lasering/Chladnipatterns/patterns.jpg">
-                            <img src="./Hobby/Lasering/Chladnipatterns/patterns2.jpg">
-                            <img src="./Hobby/Lasering/Chladnipatterns/patterns3.jpg">
-                            <img src="./Hobby/Lasering/Chladnipatterns/patterns4.jpg">
-                            <img src="./Hobby/Lasering/Chladnipatterns/patterns5.jpg">
+                            <img src="./Hobby/Lasering/Chladnipatterns/patterns.jpg" alt="patterns">
+                            <img src="./Hobby/Lasering/Chladnipatterns/patterns2.jpg" alt="patterns2">
+                            <img src="./Hobby/Lasering/Chladnipatterns/patterns3.jpg" alt="patterns3">
+                            <img src="./Hobby/Lasering/Chladnipatterns/patterns4.jpg" alt="patterns4">
+                            <img src="./Hobby/Lasering/Chladnipatterns/patterns5.jpg" alt="patterns5">
                         </div>
                     </div>
                 </div>
@@ -212,11 +212,11 @@
                     cutting can't do?</p>
                 <div class="medias">
                     <div class="images">
-                        <img src="./Hobby/Lasering/clocks/ASLclock.jpg">
-                        <img src="./Hobby/Lasering/clocks/ASLclock1.jpg">
-                        <img src="./Hobby/Lasering/clocks/ASLclock2.jpg">
-                        <img src="./Hobby/Lasering/clocks/ASLclock3.jpg">
-                        <img src="./Hobby/Lasering/clocks/ASLclock4.jpg">
+                        <img src="./Hobby/Lasering/clocks/ASLclock.jpg" alt="ASLclock">
+                        <img src="./Hobby/Lasering/clocks/ASLclock1.jpg" alt="ASLclock1">
+                        <img src="./Hobby/Lasering/clocks/ASLclock2.jpg" alt="ASLclock2">
+                        <img src="./Hobby/Lasering/clocks/ASLclock3.jpg" alt="ASLclock3">
+                        <img src="./Hobby/Lasering/clocks/ASLclock4.jpg" alt="ASLclock4">
                     </div>
                 </div>
             </div>
@@ -226,8 +226,8 @@
                 <p>I've gotten really good at lasering detailed artworks out on wood!</p>
                 <div class="medias">
                     <div class="images">
-                        <img src="./Hobby/Lasering/fanArts/breathOfFire.jpg">
-                        <img src="./Hobby/Lasering/fanArts/breathOfFire2.jpg">
+                        <img src="./Hobby/Lasering/fanArts/breathOfFire.jpg" alt="breath Of Fire">
+                        <img src="./Hobby/Lasering/fanArts/breathOfFire2.jpg" alt="breath Of Fire2">
                     </div>
                 </div>
             </div>
@@ -237,10 +237,10 @@
                 <p>My laser cutter works pretty amazingly with thin foil glued to pieces of wood!</p>
                 <div class="medias">
                     <div class="images">
-                        <img src="./Hobby/Lasering/goldFoil/NASA.jpg">
-                        <img src="./Hobby/Lasering/goldFoil/NASA1.jpg">
-                        <img src="./Hobby/Lasering/goldFoil/NASA2.jpg">
-                        <img src="./Hobby/Lasering/goldFoil/NASA3.jpg">
+                        <img src="./Hobby/Lasering/goldFoil/NASA.jpg" alt="NASA">
+                        <img src="./Hobby/Lasering/goldFoil/NASA1.jpg" alt="NASA1">
+                        <img src="./Hobby/Lasering/goldFoil/NASA2.jpg" alt="NASA2">
+                        <img src="./Hobby/Lasering/goldFoil/NASA3.jpg" alt="NASA3">
                     </div>
                 </div>
             </div>
@@ -250,9 +250,9 @@
                 <p>I've been making signs for items on sale!</p>
                 <div class="medias">
                     <div class="images">
-                        <img src="./Hobby/Lasering/signs/signs.jpg">
-                        <img src="./Hobby/Lasering/signs/signs2.jpg">
-                        <img src="./Hobby/Lasering/signs/signs3.jpg">
+                        <img src="./Hobby/Lasering/signs/signs.jpg" alt="signs">
+                        <img src="./Hobby/Lasering/signs/signs2.jpg" alt="signs2">
+                        <img src="./Hobby/Lasering/signs/signs3.jpg" alt="signs3">
                     </div>
                 </div>
             </div>
@@ -264,11 +264,11 @@
                     machine's outputs while protecting my lungs.</p>
                 <div class="medias">
                     <div class="images">
-                        <img src="./Hobby/Lasering/ventingSystem/VentingSystem1.jpg">
-                        <img src="./Hobby/Lasering/ventingSystem/VentingSystem2.jpg">
-                        <img src="./Hobby/Lasering/ventingSystem/VentingSystem3.jpg">
-                        <img src="./Hobby/Lasering/ventingSystem/VentingSystem4.jpg">
-                        <img src="./Hobby/Lasering/ventingSystem/VentingSystem5.jpg">
+                        <img src="./Hobby/Lasering/ventingSystem/VentingSystem1.jpg" alt="Venting System1">
+                        <img src="./Hobby/Lasering/ventingSystem/VentingSystem2.jpg" alt="Venting System2">
+                        <img src="./Hobby/Lasering/ventingSystem/VentingSystem3.jpg" alt="Venting System3">
+                        <img src="./Hobby/Lasering/ventingSystem/VentingSystem4.jpg" alt="Venting System4">
+                        <img src="./Hobby/Lasering/ventingSystem/VentingSystem5.jpg" alt="Venting System5">
                     </div>
                 </div>
             </div>
@@ -280,8 +280,8 @@
                 </p>
                 <div class="medias">
                     <div class="images">
-                        <img src="./Hobby/Lasering/ASLdiceGame/ASL dice game.jpg">
-                        <img src="./Hobby/Lasering/ASLdiceGame/ASL dice game2.jpg">
+                        <img src="./Hobby/Lasering/ASLdiceGame/ASL dice game.jpg" alt="ASL dice game">
+                        <img src="./Hobby/Lasering/ASLdiceGame/ASL dice game2.jpg" alt="ASL dice game2">
                     </div>
                 </div>
                 <p>The rules are as follows:</p>
@@ -395,32 +395,32 @@
                     headaches of handling molten glass, mixing dyes, etc.</p>
                 <div class="medias">
                     <div class="images">
-                        <img src="./Hobby/3Dprinting/3dPainting/andre.jpg">
-                        <img src="./Hobby/3Dprinting/3dPainting/AndreAndTree.jpg">
-                        <img src="./Hobby/3Dprinting/3dPainting/AndreGlow.jpg">
-                        <img src="./Hobby/3Dprinting/3dPainting/andreGlow2.jpg">
-                        <img src="./Hobby/3Dprinting/3dPainting/batman1.jpg">
-                        <img src="./Hobby/3Dprinting/3dPainting/batman2.jpg">
-                        <img src="./Hobby/3Dprinting/3dPainting/batman3.jpg">
-                        <img src="./Hobby/3Dprinting/3dPainting/batman4.jpg">
-                        <img src="./Hobby/3Dprinting/3dPainting/HueForge.jpg">
-                        <img src="./Hobby/3Dprinting/3dPainting/HueForge10.jpg">
-                        <img src="./Hobby/3Dprinting/3dPainting/HueForge11.jpg">
-                        <img src="./Hobby/3Dprinting/3dPainting/HueForge12.jpg">
-                        <img src="./Hobby/3Dprinting/3dPainting/Hueforge13.jpg">
-                        <img src="./Hobby/3Dprinting/3dPainting/HueForge2.jpg">
-                        <img src="./Hobby/3Dprinting/3dPainting/HueForge3.jpg">
-                        <img src="./Hobby/3Dprinting/3dPainting/HueForge4.jpg">
-                        <img src="./Hobby/3Dprinting/3dPainting/HueForge5.jpg">
-                        <img src="./Hobby/3Dprinting/3dPainting/HueForge6.jpg">
-                        <img src="./Hobby/3Dprinting/3dPainting/HueForge7.jpg">
-                        <img src="./Hobby/3Dprinting/3dPainting/HueForge8.jpg">
-                        <img src="./Hobby/3Dprinting/3dPainting/HueForge9.jpg">
-                        <img src="./Hobby/3Dprinting/3dPainting/repeatingPatterns.jpg">
-                        <img src="./Hobby/3Dprinting/3dPainting/repeatingPatterns2.jpg">
-                        <img src="./Hobby/3Dprinting/3dPainting/spaceman.jpg">
-                        <img src="./Hobby/3Dprinting/3dPainting/spaceman2.jpg">
-                        <img src="./Hobby/3Dprinting/3dPainting/spaceman3.jpg">
+                        <img src="./Hobby/3Dprinting/3dPainting/andre.jpg" alt="andre">
+                        <img src="./Hobby/3Dprinting/3dPainting/AndreAndTree.jpg" alt="Andre And Tree">
+                        <img src="./Hobby/3Dprinting/3dPainting/AndreGlow.jpg" alt="Andre Glow">
+                        <img src="./Hobby/3Dprinting/3dPainting/andreGlow2.jpg" alt="andre Glow2">
+                        <img src="./Hobby/3Dprinting/3dPainting/batman1.jpg" alt="batman1">
+                        <img src="./Hobby/3Dprinting/3dPainting/batman2.jpg" alt="batman2">
+                        <img src="./Hobby/3Dprinting/3dPainting/batman3.jpg" alt="batman3">
+                        <img src="./Hobby/3Dprinting/3dPainting/batman4.jpg" alt="batman4">
+                        <img src="./Hobby/3Dprinting/3dPainting/HueForge.jpg" alt="Hue Forge">
+                        <img src="./Hobby/3Dprinting/3dPainting/HueForge10.jpg" alt="Hue Forge10">
+                        <img src="./Hobby/3Dprinting/3dPainting/HueForge11.jpg" alt="Hue Forge11">
+                        <img src="./Hobby/3Dprinting/3dPainting/HueForge12.jpg" alt="Hue Forge12">
+                        <img src="./Hobby/3Dprinting/3dPainting/Hueforge13.jpg" alt="Hueforge13">
+                        <img src="./Hobby/3Dprinting/3dPainting/HueForge2.jpg" alt="Hue Forge2">
+                        <img src="./Hobby/3Dprinting/3dPainting/HueForge3.jpg" alt="Hue Forge3">
+                        <img src="./Hobby/3Dprinting/3dPainting/HueForge4.jpg" alt="Hue Forge4">
+                        <img src="./Hobby/3Dprinting/3dPainting/HueForge5.jpg" alt="Hue Forge5">
+                        <img src="./Hobby/3Dprinting/3dPainting/HueForge6.jpg" alt="Hue Forge6">
+                        <img src="./Hobby/3Dprinting/3dPainting/HueForge7.jpg" alt="Hue Forge7">
+                        <img src="./Hobby/3Dprinting/3dPainting/HueForge8.jpg" alt="Hue Forge8">
+                        <img src="./Hobby/3Dprinting/3dPainting/HueForge9.jpg" alt="Hue Forge9">
+                        <img src="./Hobby/3Dprinting/3dPainting/repeatingPatterns.jpg" alt="repeating Patterns">
+                        <img src="./Hobby/3Dprinting/3dPainting/repeatingPatterns2.jpg" alt="repeating Patterns2">
+                        <img src="./Hobby/3Dprinting/3dPainting/spaceman.jpg" alt="spaceman">
+                        <img src="./Hobby/3Dprinting/3dPainting/spaceman2.jpg" alt="spaceman2">
+                        <img src="./Hobby/3Dprinting/3dPainting/spaceman3.jpg" alt="spaceman3">
                     </div>
                 </div>
             </div>
@@ -430,9 +430,9 @@
                 <p>Those patterns comes out pretty nicely when 3D printed!</p>
                 <div class="medias">
                     <div class="images">
-                        <img src="./Hobby/3Dprinting/Chladnipatterns/pattern1.jpg">
-                        <img src="./Hobby/3Dprinting/Chladnipatterns/pattern2.jpg">
-                        <img src="./Hobby/3Dprinting/Chladnipatterns/pattern3.jpg">
+                        <img src="./Hobby/3Dprinting/Chladnipatterns/pattern1.jpg" alt="pattern1">
+                        <img src="./Hobby/3Dprinting/Chladnipatterns/pattern2.jpg" alt="pattern2">
+                        <img src="./Hobby/3Dprinting/Chladnipatterns/pattern3.jpg" alt="pattern3">
                     </div>
                 </div>
             </div>
@@ -442,8 +442,8 @@
                 <p>Magnets are the solution!</p>
                 <div class="medias">
                     <div class="images">
-                        <img src="./Hobby/3Dprinting/magnets/rats.jpg">
-                        <img src="./Hobby/3Dprinting/magnets/rats2.jpg">
+                        <img src="./Hobby/3Dprinting/magnets/rats.jpg" alt="rats">
+                        <img src="./Hobby/3Dprinting/magnets/rats2.jpg" alt="rats2">
                     </div>
                 </div>
             </div>
@@ -453,8 +453,8 @@
                 <p>Masks Masks Masked Masks Masks for Masks MASKS</p>
                 <div class="medias">
                     <div class="images">
-                        <img src="./Hobby/3Dprinting/mask/mask.jpg">
-                        <img src="./Hobby/3Dprinting/mask/mask2.jpg">
+                        <img src="./Hobby/3Dprinting/mask/mask.jpg" alt="mask">
+                        <img src="./Hobby/3Dprinting/mask/mask2.jpg" alt="mask2">
                     </div>
                 </div>
             </div>
@@ -465,11 +465,11 @@
                     is more useful than a map... Try getting lost in there with this in your hand!</p>
                 <div class="medias">
                     <div class="images">
-                        <img src="./Hobby/3Dprinting/renders/bathroom.jpg">
-                        <img src="./Hobby/3Dprinting/renders/bathroom2.jpg">
-                        <img src="./Hobby/3Dprinting/renders/bathroom3.jpg">
-                        <img src="./Hobby/3Dprinting/renders/bathroom4.jpg">
-                        <img src="./Hobby/3Dprinting/renders/bathroom5.jpg">
+                        <img src="./Hobby/3Dprinting/renders/bathroom.jpg" alt="bathroom">
+                        <img src="./Hobby/3Dprinting/renders/bathroom2.jpg" alt="bathroom2">
+                        <img src="./Hobby/3Dprinting/renders/bathroom3.jpg" alt="bathroom3">
+                        <img src="./Hobby/3Dprinting/renders/bathroom4.jpg" alt="bathroom4">
+                        <img src="./Hobby/3Dprinting/renders/bathroom5.jpg" alt="bathroom5">
                     </div>
                 </div>
             </div>
@@ -480,9 +480,9 @@
                     but still, it's a cool option.</p>
                 <div class="medias">
                     <div class="images">
-                        <img src="./Hobby/3Dprinting/signs/Signs.jpg">
-                        <img src="./Hobby/3Dprinting/signs/signs2.jpg">
-                        <img src="./Hobby/3Dprinting/signs/signs3.jpg">
+                        <img src="./Hobby/3Dprinting/signs/Signs.jpg" alt="Signs">
+                        <img src="./Hobby/3Dprinting/signs/signs2.jpg" alt="signs2">
+                        <img src="./Hobby/3Dprinting/signs/signs3.jpg" alt="signs3">
                     </div>
                 </div>
             </div>
@@ -492,16 +492,16 @@
                 <p>Embrace the chaos.</p>
                 <div class="medias">
                     <div class="images">
-                        <img src="./Hobby/3Dprinting/misc/batteries.jpg">
-                        <img src="./Hobby/3Dprinting/misc/Butterflies.jpg">
-                        <img src="./Hobby/3Dprinting/misc/dragon.jpg">
-                        <img src="./Hobby/3Dprinting/misc/dragon2.jpg">
-                        <img src="./Hobby/3Dprinting/misc/flexiables.jpg">
-                        <img src="./Hobby/3Dprinting/misc/lizard.jpg">
-                        <img src="./Hobby/3Dprinting/misc/lizard2.jpg">
-                        <img src="./Hobby/3Dprinting/misc/lizard3.jpg">
-                        <img src="./Hobby/3Dprinting/misc/skull.jpg">
-                        <img src="./Hobby/3Dprinting/misc/tableChair.jpg">
+                        <img src="./Hobby/3Dprinting/misc/batteries.jpg" alt="batteries">
+                        <img src="./Hobby/3Dprinting/misc/Butterflies.jpg" alt="Butterflies">
+                        <img src="./Hobby/3Dprinting/misc/dragon.jpg" alt="dragon">
+                        <img src="./Hobby/3Dprinting/misc/dragon2.jpg" alt="dragon2">
+                        <img src="./Hobby/3Dprinting/misc/flexiables.jpg" alt="flexiables">
+                        <img src="./Hobby/3Dprinting/misc/lizard.jpg" alt="lizard">
+                        <img src="./Hobby/3Dprinting/misc/lizard2.jpg" alt="lizard2">
+                        <img src="./Hobby/3Dprinting/misc/lizard3.jpg" alt="lizard3">
+                        <img src="./Hobby/3Dprinting/misc/skull.jpg" alt="skull">
+                        <img src="./Hobby/3Dprinting/misc/tableChair.jpg" alt="table Chair">
                     </div>
                 </div>
             </div>
@@ -513,12 +513,12 @@
                     put it on modern ESP32s and managed to fit everything into a laser-cut box.</p>
                 <div class="medias">
                     <div class="images">
-                        <img src="./Hobby/EmbeddedTechology/beatMonsters/BeatMonster.jpg">
-                        <img src="./Hobby/EmbeddedTechology/beatMonsters/BeatMonster2.jpg">
-                        <img src="./Hobby/EmbeddedTechology/beatMonsters/BeatMonster3.jpg">
-                        <img src="./Hobby/EmbeddedTechology/beatMonsters/BeatMonster4.jpg">
-                        <img src="./Hobby/EmbeddedTechology/beatMonsters/BeatMonster5.jpg">
-                        <img src="./Hobby/EmbeddedTechology/beatMonsters/sensorBox.jpg">
+                        <img src="./Hobby/EmbeddedTechology/beatMonsters/BeatMonster.jpg" alt="Beat Monster">
+                        <img src="./Hobby/EmbeddedTechology/beatMonsters/BeatMonster2.jpg" alt="Beat Monster2">
+                        <img src="./Hobby/EmbeddedTechology/beatMonsters/BeatMonster3.jpg" alt="Beat Monster3">
+                        <img src="./Hobby/EmbeddedTechology/beatMonsters/BeatMonster4.jpg" alt="Beat Monster4">
+                        <img src="./Hobby/EmbeddedTechology/beatMonsters/BeatMonster5.jpg" alt="Beat Monster5">
+                        <img src="./Hobby/EmbeddedTechology/beatMonsters/sensorBox.jpg" alt="sensor Box">
                     </div>
                 </div>
             </div>
@@ -539,8 +539,8 @@
                             referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
                     </div>
                     <div class="images">
-                        <img src="./Hobby/EmbeddedTechology/wearables/hapticGlove1.jpg">
-                        <img src="./Hobby/EmbeddedTechology/wearables/wearable.jpg">
+                        <img src="./Hobby/EmbeddedTechology/wearables/hapticGlove1.jpg" alt="haptic Glove1">
+                        <img src="./Hobby/EmbeddedTechology/wearables/wearable.jpg" alt="wearable">
                     </div>
                 </div>
             </div>
@@ -551,10 +551,10 @@
                     constantly.</p>
                 <div class="medias">
                     <div class="images">
-                        <img src="./Hobby/EmbeddedTechology/scream-time clock/Scream-TimeClock.jpg">
-                        <img src="./Hobby/EmbeddedTechology/scream-time clock/Scream-TimeClock2.jpg">
-                        <img src="./Hobby/EmbeddedTechology/scream-time clock/Scream-TimeClock3.jpg">
-                        <img src="./Hobby/EmbeddedTechology/scream-time clock/Scream-TimeClock4.jpg">
+                        <img src="./Hobby/EmbeddedTechology/scream-time clock/Scream-TimeClock.jpg" alt="Scream Time Clock">
+                        <img src="./Hobby/EmbeddedTechology/scream-time clock/Scream-TimeClock2.jpg" alt="Scream Time Clock2">
+                        <img src="./Hobby/EmbeddedTechology/scream-time clock/Scream-TimeClock3.jpg" alt="Scream Time Clock3">
+                        <img src="./Hobby/EmbeddedTechology/scream-time clock/Scream-TimeClock4.jpg" alt="Scream Time Clock4">
                     </div>
                 </div>
             </div>
@@ -566,9 +566,9 @@
                 <p>The wall outside my lab. It overflows!</p>
                 <div class="medias">
                     <div class="images">
-                        <img src="./Hobby/displayWall.jpg">
-                        <img src="./Hobby/displayWall2.jpg">
-                        <img src="./Hobby/displayWall3.jpg">
+                        <img src="./Hobby/displayWall.jpg" alt="display Wall">
+                        <img src="./Hobby/displayWall2.jpg" alt="display Wall2">
+                        <img src="./Hobby/displayWall3.jpg" alt="display Wall3">
                     </div>
                 </div>
             </div>
@@ -580,9 +580,9 @@
                     to get rid of artworks before I drown in them. I'm way more interested in making than keeping.</p>
                 <div class="medias">
                     <div class="images">
-                        <img src="./Hobby/saleKioskAtDeafCafe.jpg">
-                        <img src="./Hobby/saleKioskAtDeafCafe2.jpg">
-                        <img src="./Hobby/saleKioskAtDeafCafe3.jpg">
+                        <img src="./Hobby/saleKioskAtDeafCafe.jpg" alt="sale Kiosk At Deaf Cafe">
+                        <img src="./Hobby/saleKioskAtDeafCafe2.jpg" alt="sale Kiosk At Deaf Cafe2">
+                        <img src="./Hobby/saleKioskAtDeafCafe3.jpg" alt="sale Kiosk At Deaf Cafe3">
                     </div>
                 </div>
             </div>
@@ -605,7 +605,7 @@
                     something pretty neat!
                 </p>
                 <figure>
-                    <img src="./Images/StemKits/STEMkit.png">
+                    <img src="./Images/StemKits/STEMkit.png" alt="STEMkit">
                     <figcaption>CymaSpace's basic STEM kit, designed for all age!</figcaption>
                 </figure>
 
@@ -624,10 +624,10 @@
                     themes, lights, motors, sensing, etc.
                 </p>
                 <div class="medias">
-                    <img src="./Images/StemKits/StemKitHeld.jpg">
-                    <img src="./Images/StemKits/StemKittop.jpg">
-                    <img src="./Images/StemKits/stemKitLasered.jpg">
-                    <img src="./Images/StemKits/StemKitBackside.jpg">
+                    <img src="./Images/StemKits/StemKitHeld.jpg" alt="Stem Kit Held">
+                    <img src="./Images/StemKits/StemKittop.jpg" alt="Stem Kittop">
+                    <img src="./Images/StemKits/stemKitLasered.jpg" alt="stem Kit Lasered">
+                    <img src="./Images/StemKits/StemKitBackside.jpg" alt="Stem Kit Backside">
                 </div>
             </div>
 
@@ -655,12 +655,12 @@
                     event.
                 </p>
                 <figure>
-                    <img src="./Images/LedControllerWorkshop/LedControllerWorkshop.webp">
+                    <img src="./Images/LedControllerWorkshop/LedControllerWorkshop.webp" alt="Led Controller Workshop">
                     <figcaption>The flyer for the event!</figcaption>
                 </figure>
 
                 <figure>
-                    <img src="./Images/LedControllerWorkshop/ledKIT.jpeg">
+                    <img src="./Images/LedControllerWorkshop/ledKIT.jpeg" alt="led KIT">
                     <figcaption>The LED kits I pulled together for the workshop</figcaption>
                 </figure>
             </div>
@@ -675,7 +675,7 @@
                 <a href="https://nime.org/proc/nime2024_15/"> Link to the research paper</a>
 
                 <figure>
-                    <img src="./Images/HapticBracerDemoBunnie.jpg">
+                    <img src="./Images/HapticBracerDemoBunnie.jpg" alt="Haptic Bracer Demo Bunnie">
                     <figcaption><a href="https://en.wikipedia.org/wiki/Andrew_Huang_(hacker)">Andrew Huang wearing the
                             GeLu Prototype 3!</a></figcaption>
                 </figure>
@@ -732,7 +732,7 @@
                     rebuild, and a strong reminder that curiosity scales way better than volume knobs.
                 </p>
                 <figure>
-                    <img src="./Images/hapticZoo.jpg">
+                    <img src="./Images/hapticZoo.jpg" alt="haptic Zoo">
                     <figcaption>The Universal Music Design group</figcaption>
                 </figure>
             </div>


### PR DESCRIPTION
## Summary
- Provide descriptive alt text for all portfolio images.
- Assign alt text to dynamically generated asset images.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68986fd9551083339ee669dd736ab5cb